### PR TITLE
Short BSON strings are interned while parsed

### DIFF
--- a/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/ByteBufBsonInputAdaptor.java
+++ b/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/ByteBufBsonInputAdaptor.java
@@ -9,6 +9,8 @@ import org.bson.io.BsonInput;
 import org.bson.types.ObjectId;
 
 /**
+ * This class is an adaptor that wraps a netty {@link ByteBuf} and shows it as
+ * a {@link BsonInput}.
  *
  */
 @SuppressFBWarnings(

--- a/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/ByteBufUtil.java
+++ b/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/ByteBufUtil.java
@@ -62,7 +62,11 @@ public class ByteBufUtil {
     }
 
     public static BsonDocument readBsonDocument(ByteBuf buffer) {
-        BsonReader reader = new BsonBinaryReader(new ByteBufBsonInputAdaptor(buffer));
+        BsonReader reader = new BsonBinaryReader(
+                new InternBsonInputDelegator(
+                        new ByteBufBsonInputAdaptor(buffer)
+                )
+        );
 
         DecoderContext context = DecoderContext.builder().build();
         return BSON_CODEC.decode(reader, context);

--- a/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/InternBsonInputDelegator.java
+++ b/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/InternBsonInputDelegator.java
@@ -1,0 +1,133 @@
+
+package com.eightkdata.mongowp.mongoserver.util;
+
+import org.bson.io.BsonInput;
+import org.bson.types.ObjectId;
+
+/**
+ * This {@link BsonInput} delegates on another one but
+ * {@linkplain String#intern() interns} all generated strings.
+ */
+public class InternBsonInputDelegator implements BsonInput {
+
+    private final BsonInput delegate;
+
+    public InternBsonInputDelegator(BsonInput delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * A predicate that decides if a string should be interned or not.
+     *
+     * There are several valid heuristics: key fields (which are read with
+     * {@link #readCString()}) are good candidates to be interned, as they
+     * tend to be repeated. But some string values are used as enum literals,
+     * so they are usually repeated.
+     *
+     * The chosen heuristic is that all not too long strings are interned. It
+     * is fast to evaluate, easy to implement and it should return true for both
+     * key fields and enum values.
+     * @param str
+     * @return
+     */
+    private boolean isInternable(String str) {
+        return str.length() < 80;
+    }
+
+    @Override
+    public int getPosition() {
+        return delegate.getPosition();
+    }
+
+    @Override
+    public byte readByte() {
+        return delegate.readByte();
+    }
+
+    @Override
+    public void readBytes(byte[] bytes) {
+        delegate.readBytes(bytes);
+    }
+
+    @Override
+    public void readBytes(byte[] bytes, int offset, int length) {
+        delegate.readBytes(bytes, offset, length);
+    }
+
+    @Override
+    public long readInt64() {
+        return delegate.readInt64();
+    }
+
+    @Override
+    public double readDouble() {
+        return delegate.readDouble();
+    }
+
+    @Override
+    public int readInt32() {
+        return delegate.readInt32();
+    }
+
+    @Override
+    public String readString() {
+        String originalString = delegate.readString();
+        String result;
+        if (isInternable(originalString)) {
+            result = originalString.intern();
+        }
+        else {
+            result = originalString;
+        }
+        return result;
+    }
+
+    @Override
+    public ObjectId readObjectId() {
+        return delegate.readObjectId();
+    }
+
+    @Override
+    public String readCString() {
+        String originalString = delegate.readCString();
+        String result;
+        if (isInternable(originalString)) {
+            result = originalString.intern();
+        }
+        else {
+            result = originalString;
+        }
+        return result;
+    }
+
+    @Override
+    public void skipCString() {
+        delegate.skipCString();
+    }
+
+    @Override
+    public void skip(int numBytes) {
+        delegate.skip(numBytes);
+    }
+
+    @Override
+    public void mark(int readLimit) {
+        delegate.mark(readLimit);
+    }
+
+    @Override
+    public void reset() {
+        delegate.reset();
+    }
+
+    @Override
+    public boolean hasRemaining() {
+        return delegate.hasRemaining();
+    }
+
+    @Override
+    public void close() {
+        delegate.close();
+    }
+
+}


### PR DESCRIPTION
Short string are usually repeated on BSON documents (they are widely
used as field keys and sometimes as enum literal values). As MongoWP
requires JDK 7, we can easily reduce the memory pressure related with
this kind of strings using java.lang.String#intern(), the standard
string pool provided by the JVM.

Right now all bson strings sent by the clients are interned iff its
lenght is lower than 80 characters.