### PR TITLE
Fixed a bug on the drop collection command name

### DIFF
--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/admin/DropCollectionCommand.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/admin/DropCollectionCommand.java
@@ -17,7 +17,7 @@ public class DropCollectionCommand extends AbstractCommand<CollectionCommandArgu
     public static final DropCollectionCommand INSTANCE = new DropCollectionCommand();
 
     private DropCollectionCommand() {
-        super("dropCollection");
+        super("drop");
     }
 
     @Override


### PR DESCRIPTION
The command used to drop collections is called _drop_, but it was
declared as _dropCollection_. As a command execution is decided by the
command name, the command was impossible to execute with the new API