### PR TITLE
Unit tests were not executed on _safer_ profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,9 +335,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <version>2.19</version>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
                         <executions>
                             <execution>
                                 <id>integration-tests</id>


### PR DESCRIPTION
Safer profile overrides surfire plugin and set skip property to true.
That property skips the execution with id _default-test_, which is, by
convention, the default execution where unit tests are executed.