### PR TITLE
String values whose lenght is less than 5 characters will be interned

### DIFF
--- a/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/InternBsonInputDelegator.java
+++ b/mongo-server/src/main/java/com/eightkdata/mongowp/mongoserver/util/InternBsonInputDelegator.java
@@ -53,7 +53,7 @@ public class InternBsonInputDelegator implements BsonInput {
             return str.length() < 80;
         }
         else {
-            return false;
+            return str.length() < 5;
         }
     }
 


### PR DESCRIPTION
Doing that, we try to improve the efficiency when short strings are
used as literals.