### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/bson/bson-core/pom.xml
+++ b/bson/bson-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.bson</groupId>
         <artifactId>bson-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>bson-core</artifactId>
     <packaging>jar</packaging>

--- a/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/abst/AbstractBsonDeprecated.java
+++ b/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/abst/AbstractBsonDeprecated.java
@@ -36,7 +36,7 @@ public abstract class AbstractBsonDeprecated extends AbstractBsonValue<String> i
 
     @Override
     public BsonType getType() {
-        return BsonType.STRING;
+        return BsonType.DEPRECTED;
     }
 
     @Override

--- a/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/abst/AbstractBsonJavaScript.java
+++ b/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/abst/AbstractBsonJavaScript.java
@@ -36,7 +36,7 @@ public abstract class AbstractBsonJavaScript extends AbstractBsonValue<String> i
 
     @Override
     public BsonType getType() {
-        return BsonType.STRING;
+        return BsonType.JAVA_SCRIPT;
     }
 
     @Override

--- a/bson/bson-netty/pom.xml
+++ b/bson/bson-netty/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.bson</groupId>
         <artifactId>bson-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>bson-netty</artifactId>
     <packaging>jar</packaging>

--- a/bson/bson-netty/src/main/java/com/eightkdata/mongowp/bson/netty/ParsingTools.java
+++ b/bson/bson-netty/src/main/java/com/eightkdata/mongowp/bson/netty/ParsingTools.java
@@ -40,6 +40,9 @@ class ParsingTools {
 
     private static final byte FIRST_USER_DEFINED = UnsignedBytes.parseUnsignedByte("80", 16);
 
+    private ParsingTools() {
+    }
+
     /**
      * Translate a byte to the {@link BsonType} it represents, as specified on
      * the <a href="http://bsonspec.org/spec.html">BSON Spec</a>

--- a/bson/bson-netty/src/test/java/com/eightkdata/mongowp/bson/netty/MongoDocumentProvider.java
+++ b/bson/bson-netty/src/test/java/com/eightkdata/mongowp/bson/netty/MongoDocumentProvider.java
@@ -35,6 +35,9 @@ public class MongoDocumentProvider {
 
     private static final String testDocumentsFileName = "test-documents.json";
 
+    private MongoDocumentProvider() {
+    }
+
     public static Collection<Object[]> readTestDocuments() throws IOException {
         try (InputStream is = MongoDocumentProvider.class.getResourceAsStream('/' + testDocumentsFileName)) {
             BsonValue value = MongoBsonUtils.read(is);

--- a/bson/org-bson-utils/pom.xml
+++ b/bson/org-bson-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.bson</groupId>
         <artifactId>bson-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>org-bson-utils</artifactId>
     <packaging>jar</packaging>

--- a/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
+++ b/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
@@ -13,6 +13,8 @@ import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.bson.*;
 import org.bson.types.ObjectId;
 import org.slf4j.Logger;
@@ -29,15 +31,22 @@ public class MongoBsonTranslator {
     public static final Function<com.eightkdata.mongowp.bson.BsonDocument, BsonDocument> TO_MONGO_FUNCTION = new ToMongoFunction();
     private static final byte FIRST_USER_DEFINED = UnsignedBytes.parseUnsignedByte("80", 16);
 
-    public static BsonDocument translate(com.eightkdata.mongowp.bson.BsonDocument wpDocument) throws IOException {
+    @Nullable
+    public static BsonDocument translate(@Nullable com.eightkdata.mongowp.bson.BsonDocument wpDocument) throws IOException {
         return (BsonDocument) _translate(wpDocument);
     }
 
-    public static com.eightkdata.mongowp.bson.BsonDocument translate(org.bson.BsonDocument mongoDocument) {
+    @Nullable
+    public static com.eightkdata.mongowp.bson.BsonDocument translate(@Nullable org.bson.BsonDocument mongoDocument) {
         return (com.eightkdata.mongowp.bson.BsonDocument) _translate(mongoDocument);
     }
 
-    private static BsonValue _translate(com.eightkdata.mongowp.bson.BsonValue<?> value) throws IOException {
+    @Nullable
+    private static BsonValue _translate(@Nullable com.eightkdata.mongowp.bson.BsonValue<?> value) throws IOException {
+    	if (value == null) {
+    		return null;
+    	}
+    	
         switch (value.getType()) {
             case ARRAY:  {
                 com.eightkdata.mongowp.bson.BsonArray casted = (com.eightkdata.mongowp.bson.BsonArray) value;
@@ -117,7 +126,11 @@ public class MongoBsonTranslator {
         return new ObjectId(id.toHexString());
     }
 
-    private static com.eightkdata.mongowp.bson.BsonValue<?> _translate(BsonValue value) {
+    @Nullable
+    private static com.eightkdata.mongowp.bson.BsonValue<?> _translate(@Nullable BsonValue value) {
+    	if (value == null) {
+    		return null;
+    	}
         switch (value.getBsonType()) {
             case ARRAY:  {
                 List<com.eightkdata.mongowp.bson.BsonValue<?>> list = new ArrayList<>();

--- a/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
+++ b/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
@@ -31,6 +31,9 @@ public class MongoBsonTranslator {
     public static final Function<com.eightkdata.mongowp.bson.BsonDocument, BsonDocument> TO_MONGO_FUNCTION = new ToMongoFunction();
     private static final byte FIRST_USER_DEFINED = UnsignedBytes.parseUnsignedByte("80", 16);
 
+    private MongoBsonTranslator() {
+    }
+
     @Nullable
     public static BsonDocument translate(@Nullable com.eightkdata.mongowp.bson.BsonDocument wpDocument) throws IOException {
         return (BsonDocument) _translate(wpDocument);

--- a/bson/pom.xml
+++ b/bson/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp</groupId>
         <artifactId>mongowp-parent</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.8kdata.mongowp.bson</groupId>

--- a/client/core/pom.xml
+++ b/client/core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.client</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/client/driver-wrapper/pom.xml
+++ b/client/driver-wrapper/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.client</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <artifactId>driver-wrapper</artifactId>

--- a/client/driver-wrapper/src/main/java/com/eightkdata/mongowp/client/wrapper/MongoConnectionWrapper.java
+++ b/client/driver-wrapper/src/main/java/com/eightkdata/mongowp/client/wrapper/MongoConnectionWrapper.java
@@ -330,11 +330,10 @@ public class MongoConnectionWrapper implements MongoConnection {
         @Override
         public Iterator<BsonDocument> iterator() {
             Preconditions.checkState(!close, "This cursor is closed");
-            Iterators.transform(
+            return Iterators.transform(
                     cursor,
                     MongoBsonTranslator.FROM_MONGO_FUNCTION
             );
-            return null;
         }
 
     }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp</groupId>
         <artifactId>mongowp-parent</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.8kdata.mongowp.client</groupId>

--- a/library/pom.xml
+++ b/library/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp</groupId>
         <artifactId>mongowp-parent</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.8kdata.mongowp.api.safe.library</groupId>

--- a/library/v3m0/pom.xml
+++ b/library/v3m0/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.api.safe.library</groupId>
         <artifactId>library</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <artifactId>v3m0</artifactId>

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/general/UpdateCommand.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/general/UpdateCommand.java
@@ -347,7 +347,7 @@ public class UpdateCommand extends AbstractCommand<UpdateArgument, UpdateResult>
                 }
                 builder.append(WRITE_CONCERN_ERRORS_FIELD, array.build());
             }
-            if (upserts.isEmpty()) {
+            if (!upserts.isEmpty()) {
                 BsonArrayBuilder array = new BsonArrayBuilder();
                 for (UpsertResult upsert : upserts) {
                     array.add(upsert.marshall());

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/repl/IsMasterCommand.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/commands/repl/IsMasterCommand.java
@@ -263,7 +263,7 @@ public class IsMasterCommand extends AbstractCommand<Empty, IsMasterReply> {
                                         + "found type " + uncastedValue.getType()
                         );
                     }
-                    resultBuilder.add(HostAndPort.fromString(uncastedList.asString().getValue()));
+                    resultBuilder.add(BsonReaderTool.getHostAndPort(uncastedList.asString().getValue()));
                 }
                 return resultBuilder.build();
             }

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/HeartbeatInfo.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/HeartbeatInfo.java
@@ -96,7 +96,7 @@ public class HeartbeatInfo {
         String setName = BsonReaderTool.getString(bson, SET_NAME_FIELD_NAME);
         
         String senderHostString = BsonReaderTool.getString(bson, SENDER_HOST_FIELD_NAME, null);
-        HostAndPort senderHost = senderHostString != null ? HostAndPort.fromString(senderHostString) : null;
+        HostAndPort senderHost = senderHostString != null ? BsonReaderTool.getHostAndPort(senderHostString) : null;
         
         return new HeartbeatInfo(protocolVersion, configVersion, setName, senderHost, senderId, checkEmpty);
     }

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
@@ -228,7 +228,7 @@ public class IndexOptions {
                     break;
                 }
                 case EXPIRE_AFTER_SECONDS_FIELD_NAME: {
-                    expireAfterSeconds = BsonReaderTool.getInteger(entry, EXPIRE_AFTER_SECONDS_FIELD);
+                    expireAfterSeconds = BsonReaderTool.getNumeric(entry, EXPIRE_AFTER_SECONDS_FIELD.getFieldName()).intValue();
                     break;
                 }
                 case KEYS_FIELD_NAME: {

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
@@ -1,27 +1,31 @@
 
 package com.eightkdata.mongowp.mongoserver.api.safe.library.v3m0.pojos;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import com.eightkdata.mongowp.bson.BsonDocument;
 import com.eightkdata.mongowp.bson.BsonDocument.Entry;
-import com.eightkdata.mongowp.bson.BsonInt32;
 import com.eightkdata.mongowp.bson.BsonValue;
 import com.eightkdata.mongowp.bson.utils.DefaultBsonValues;
 import com.eightkdata.mongowp.exceptions.BadValueException;
 import com.eightkdata.mongowp.exceptions.NoSuchKeyException;
 import com.eightkdata.mongowp.exceptions.TypesMismatchException;
-import com.eightkdata.mongowp.fields.*;
+import com.eightkdata.mongowp.fields.BooleanField;
+import com.eightkdata.mongowp.fields.DocField;
+import com.eightkdata.mongowp.fields.IntField;
+import com.eightkdata.mongowp.fields.NumberField;
+import com.eightkdata.mongowp.fields.StringField;
 import com.eightkdata.mongowp.utils.BsonDocumentBuilder;
 import com.eightkdata.mongowp.utils.BsonReaderTool;
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Maps;
-import java.util.Collections;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  *
@@ -266,7 +270,7 @@ public class IndexOptions {
             IndexType value = null;
             
             for (IndexType indexType : IndexType.values()) {
-                if (indexType.toBsonValue().equals(entry.getValue())) {
+                if (indexType.equalsToBsonValue(entry.getValue())) {
                     value = indexType;
                     break;
                 }
@@ -339,8 +343,18 @@ public class IndexOptions {
     }
 
     public enum IndexType {
-        asc(DefaultBsonValues.newInt(1)), 
-        desc(DefaultBsonValues.newInt(-1)),
+        asc(DefaultBsonValues.newInt(1)) {
+            @Override
+            public boolean equalsToBsonValue(BsonValue<?> bsonValue) {
+                return sameNumber(bsonValue);
+            }
+        }, 
+        desc(DefaultBsonValues.newInt(-1)) {
+            @Override
+            public boolean equalsToBsonValue(BsonValue<?> bsonValue) {
+                return sameNumber(bsonValue);
+            }
+        },
         text(DefaultBsonValues.newString("text")),
         geospatial(DefaultBsonValues.newString("geospatial")),
         hashed(DefaultBsonValues.newString("hashed")); 
@@ -353,6 +367,16 @@ public class IndexOptions {
         
         public BsonValue<?> toBsonValue() {
             return bsonValue;
+        }
+        
+        public boolean equalsToBsonValue(BsonValue<?> bsonValue) {
+            return this.bsonValue.equals(bsonValue);
+        }
+        
+        protected boolean sameNumber(BsonValue<?> bsonValue) {
+            return bsonValue.isNumber() && 
+                    toBsonValue().asInt32()
+                        .equals(bsonValue.asInt32());
         }
     }
     

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/OplogOperationParser.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/OplogOperationParser.java
@@ -81,7 +81,7 @@ public class OplogOperationParser {
             collection = ns.substring(firstDotIndex + 1);
         }
         
-        OpTime optime = new OpTime(BsonReaderTool.getInstant(doc, "ts"));
+        OpTime optime = BsonReaderTool.getOpTime(doc, "ts");
         long h = BsonReaderTool.getLong(doc, "h");
         OplogVersion version = OplogVersion.valueOf(BsonReaderTool.getInteger(doc, "v"));
         boolean fromMigrate = doc.containsKey("fromMigrate"); //Note: Mongodb v3 checks if the key exists or not, but doesn't check the value

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/tools/CursorMarshaller.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/tools/CursorMarshaller.java
@@ -32,6 +32,9 @@ public class CursorMarshaller {
     private static final StringField NAMESPACE_FIELD = new StringField("ns");
     private static final ArrayField FIRST_BATCH_FIELD = new ArrayField("firstBatch");
 
+    private CursorMarshaller() {
+    }
+
     public static <T> BsonDocument marshall(
             MongoCursor<T> cursor,
             Function<T, ? extends BsonValue> conversor) throws MongoException {

--- a/mongowp-core/pom.xml
+++ b/mongowp-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp</groupId>
         <artifactId>mongowp-parent</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>mongowp-core</artifactId>
     <packaging>jar</packaging>

--- a/mongowp-core/src/main/java/com/eightkdata/mongowp/MongoConstants.java
+++ b/mongowp-core/src/main/java/com/eightkdata/mongowp/MongoConstants.java
@@ -30,6 +30,7 @@ import com.google.common.primitives.Ints;
  */
 public class MongoConstants {
 
+    public static final int DEFAULT_PORT = 27017;
     //TODO: MAX_MESSAGE_SIZE_BYTES is a value that the server could change, so it should be configurable
     public static final int MAX_MESSAGE_SIZE_BYTES = 48 * 1000 * 1000;
     public static final int MESSAGE_LENGTH_FIELD_BYTES = Ints.BYTES;

--- a/mongowp-core/src/main/java/com/eightkdata/mongowp/utils/BsonReaderTool.java
+++ b/mongowp-core/src/main/java/com/eightkdata/mongowp/utils/BsonReaderTool.java
@@ -1,6 +1,7 @@
 
 package com.eightkdata.mongowp.utils;
 
+import com.eightkdata.mongowp.MongoConstants;
 import com.eightkdata.mongowp.OpTime;
 import com.eightkdata.mongowp.bson.BsonDocument.Entry;
 import com.eightkdata.mongowp.bson.*;
@@ -21,7 +22,7 @@ import org.threeten.bp.Instant;
  *
  */
 public class BsonReaderTool {
-
+    
     private BsonReaderTool() {}
 
     public static String toStringBsonType(BsonType type) {
@@ -522,7 +523,12 @@ public class BsonReaderTool {
     @Nonnull
     public static HostAndPort getHostAndPort(Entry<?> entry, String fieldId) throws TypesMismatchException {
         String string = getString(entry, fieldId);
-        return HostAndPort.fromString(string);
+        return getHostAndPort(string);
+    }
+    
+    public static HostAndPort getHostAndPort(String hostPortString) {
+        return HostAndPort.fromString(hostPortString)
+                .withDefaultPort(MongoConstants.DEFAULT_PORT);
     }
 
     @Nonnull

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
     <groupId>com.8kdata.mongowp</groupId>
     <artifactId>mongowp-parent</artifactId>
-    <version>0.40-alpha3</version>
+    <version>0.40-alpha4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/server/mongo-server-api/pom.xml
+++ b/server/mongo-server-api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.server</groupId>
         <artifactId>mongo-server-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>mongo-server-api</artifactId>
     <packaging>jar</packaging>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp</groupId>
         <artifactId>mongowp-parent</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <groupId>com.8kdata.mongowp.server</groupId>

--- a/server/server-core/pom.xml
+++ b/server/server-core/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.server</groupId>
         <artifactId>mongo-server-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
 
     <artifactId>mongo-server-core</artifactId>

--- a/server/wp-layer/pom.xml
+++ b/server/wp-layer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.8kdata.mongowp.server</groupId>
         <artifactId>mongo-server-pom</artifactId>
-        <version>0.40-alpha3</version>
+        <version>0.40-alpha4-SNAPSHOT</version>
     </parent>
     <artifactId>wp-layer</artifactId>
     <packaging>jar</packaging>

--- a/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/decoder/BaseMessageDecoder.java
+++ b/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/decoder/BaseMessageDecoder.java
@@ -31,6 +31,9 @@ import java.net.InetSocketAddress;
  *
  */
 public class BaseMessageDecoder {
+    private BaseMessageDecoder() {
+    }
+
     /**
      * Method that constructs a RequestBaseMessage object based on a correctly-positioned ByteBuf.
      * This method modifies the internal state of the ByteBuf.

--- a/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/util/EnumInt32FlagsUtil.java
+++ b/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/util/EnumInt32FlagsUtil.java
@@ -32,6 +32,9 @@ import javax.annotation.Nullable;
  */
 public class EnumInt32FlagsUtil {
 
+    private EnumInt32FlagsUtil() {
+    }
+
     public static boolean isActive(EnumBitFlags flag, int flags) {
         return (flags & 1 << flag.getFlagBitPosition()) != 0;
     }

--- a/server/wp-layer/src/test/java/com/eightkdata/mongowp/mongoserver/util/AssertSetsUtil.java
+++ b/server/wp-layer/src/test/java/com/eightkdata/mongowp/mongoserver/util/AssertSetsUtil.java
@@ -29,6 +29,9 @@ import java.util.Set;
  *
  */
 public class AssertSetsUtil {
+    private AssertSetsUtil() {
+    }
+
     public static <T> boolean assertSetsEqual(Set<T> a, Set<T> b) {
         if(a == null || b == null) {
             return a == b;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.