### PR TITLE
 Nested "enum"s should not be declared static

### DIFF
--- a/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/BsonRegex.java
+++ b/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/BsonRegex.java
@@ -58,7 +58,7 @@ public interface BsonRegex extends BsonValue<BsonRegex> {
     @Override
     public int hashCode();
 
-    public static enum Options {
+    public enum Options {
         /**
          * Usually defined as <em>i</em>.
          */

--- a/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/utils/BsonDocumentReader.java
+++ b/bson/bson-core/src/main/java/com/eightkdata/mongowp/bson/utils/BsonDocumentReader.java
@@ -47,7 +47,7 @@ public interface BsonDocumentReader<Source> {
     @Nonnull
     public BsonDocument readDocument(AllocationType allocationType, Source source) throws BsonDocumentReaderException;
 
-    public static enum AllocationType {
+    public enum AllocationType {
         /**
          * Returns documents that are totally stored on the heap.
          */

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/CollectionOptions.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/CollectionOptions.java
@@ -234,7 +234,7 @@ public abstract class CollectionOptions {
 
     }
 
-    public static enum AutoIndexMode {
+    public enum AutoIndexMode {
         /**
          * {@linkplain #YES} for most collections, {@linkplain #NO} for some system ones
          */
@@ -243,7 +243,7 @@ public abstract class CollectionOptions {
         NO
     }
 
-    public static enum Flag {
+    public enum Flag {
         USE_POWER_OF_2(0),
         NO_PADDING(1);
 

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
@@ -296,7 +296,7 @@ public class IndexOptions {
         );
     }
 
-    public static enum IndexVersion {
+    public enum IndexVersion {
         V1,
         V2;
 

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/MemberHeartbeatData.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/MemberHeartbeatData.java
@@ -89,7 +89,7 @@ public class MemberHeartbeatData {
         return lastResponse.getConfigVersion();
     }
 
-    public static enum Health {
+    public enum Health {
         NOT_CHECKED(-1),
         UNREACHABLE(0),
         UP(1);

--- a/mongowp-core/src/main/java/com/eightkdata/mongowp/WriteConcern.java
+++ b/mongowp-core/src/main/java/com/eightkdata/mongowp/WriteConcern.java
@@ -268,11 +268,11 @@ public abstract class WriteConcern {
         }
     }
 
-    public static enum SyncMode {
+    public enum SyncMode {
         NONE, FSYNC, JOURNAL
     }
 
-    public static enum WType {
+    public enum WType {
         INT, TEXT;
     }
 }

--- a/mongowp-core/src/main/java/com/eightkdata/mongowp/messages/request/QueryMessage.java
+++ b/mongowp-core/src/main/java/com/eightkdata/mongowp/messages/request/QueryMessage.java
@@ -296,7 +296,7 @@ public class QueryMessage extends AbstractRequestMessage {
 
     }
 
-    public static enum QueryOption {
+    public enum QueryOption {
         TAILABLE_CURSOR,
         SLAVE_OK,
         OPLOG_REPLAY,
@@ -306,14 +306,14 @@ public class QueryMessage extends AbstractRequestMessage {
         PARTIAL;
     }
 
-    public static enum ExplainOption {
+    public enum ExplainOption {
         NONE,
         QUERY_PLANNER,
         EXECUTION_STATS,
         ALL_PLANS_EXECUTION;
     }
 
-    public static enum NaturalOrder {
+    public enum NaturalOrder {
         NONE,
         DESC,
         ASC

--- a/server/mongo-server-api/src/main/java/com/eightkdata/mongowp/server/api/deprecated/MetaCommandProcessor.java
+++ b/server/mongo-server-api/src/main/java/com/eightkdata/mongowp/server/api/deprecated/MetaCommandProcessor.java
@@ -175,7 +175,7 @@ public abstract class MetaCommandProcessor {
         }
     }
 
-    public static enum META_COLLECTION {
+    public enum META_COLLECTION {
         NAMESPACES,
         INDEXES,
         PROFILE,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2786 - “Nested "enum"s should not be declared static”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2786
Please let me know if you have any questions.
Ayman Abdelghany.