### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/bson/bson-netty/src/main/java/com/eightkdata/mongowp/bson/netty/ParsingTools.java
+++ b/bson/bson-netty/src/main/java/com/eightkdata/mongowp/bson/netty/ParsingTools.java
@@ -40,6 +40,9 @@ class ParsingTools {
 
     private static final byte FIRST_USER_DEFINED = UnsignedBytes.parseUnsignedByte("80", 16);
 
+    private ParsingTools() {
+    }
+
     /**
      * Translate a byte to the {@link BsonType} it represents, as specified on
      * the <a href="http://bsonspec.org/spec.html">BSON Spec</a>

--- a/bson/bson-netty/src/test/java/com/eightkdata/mongowp/bson/netty/MongoDocumentProvider.java
+++ b/bson/bson-netty/src/test/java/com/eightkdata/mongowp/bson/netty/MongoDocumentProvider.java
@@ -35,6 +35,9 @@ public class MongoDocumentProvider {
 
     private static final String testDocumentsFileName = "test-documents.json";
 
+    private MongoDocumentProvider() {
+    }
+
     public static Collection<Object[]> readTestDocuments() throws IOException {
         try (InputStream is = MongoDocumentProvider.class.getResourceAsStream('/' + testDocumentsFileName)) {
             BsonValue value = MongoBsonUtils.read(is);

--- a/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
+++ b/bson/org-bson-utils/src/main/java/com/eightkdata/mongowp/bson/org/bson/utils/MongoBsonTranslator.java
@@ -31,6 +31,9 @@ public class MongoBsonTranslator {
     public static final Function<com.eightkdata.mongowp.bson.BsonDocument, BsonDocument> TO_MONGO_FUNCTION = new ToMongoFunction();
     private static final byte FIRST_USER_DEFINED = UnsignedBytes.parseUnsignedByte("80", 16);
 
+    private MongoBsonTranslator() {
+    }
+
     @Nullable
     public static BsonDocument translate(@Nullable com.eightkdata.mongowp.bson.BsonDocument wpDocument) throws IOException {
         return (BsonDocument) _translate(wpDocument);

--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/tools/CursorMarshaller.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/tools/CursorMarshaller.java
@@ -32,6 +32,9 @@ public class CursorMarshaller {
     private static final StringField NAMESPACE_FIELD = new StringField("ns");
     private static final ArrayField FIRST_BATCH_FIELD = new ArrayField("firstBatch");
 
+    private CursorMarshaller() {
+    }
+
     public static <T> BsonDocument marshall(
             MongoCursor<T> cursor,
             Function<T, ? extends BsonValue> conversor) throws MongoException {

--- a/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/decoder/BaseMessageDecoder.java
+++ b/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/decoder/BaseMessageDecoder.java
@@ -31,6 +31,9 @@ import java.net.InetSocketAddress;
  *
  */
 public class BaseMessageDecoder {
+    private BaseMessageDecoder() {
+    }
+
     /**
      * Method that constructs a RequestBaseMessage object based on a correctly-positioned ByteBuf.
      * This method modifies the internal state of the ByteBuf.

--- a/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/util/EnumInt32FlagsUtil.java
+++ b/server/wp-layer/src/main/java/com/eightkdata/mongowp/server/util/EnumInt32FlagsUtil.java
@@ -32,6 +32,9 @@ import javax.annotation.Nullable;
  */
 public class EnumInt32FlagsUtil {
 
+    private EnumInt32FlagsUtil() {
+    }
+
     public static boolean isActive(EnumBitFlags flag, int flags) {
         return (flags & 1 << flag.getFlagBitPosition()) != 0;
     }

--- a/server/wp-layer/src/test/java/com/eightkdata/mongowp/mongoserver/util/AssertSetsUtil.java
+++ b/server/wp-layer/src/test/java/com/eightkdata/mongowp/mongoserver/util/AssertSetsUtil.java
@@ -29,6 +29,9 @@ import java.util.Set;
  *
  */
 public class AssertSetsUtil {
+    private AssertSetsUtil() {
+    }
+
     public static <T> boolean assertSetsEqual(Set<T> a, Set<T> b) {
         if(a == null || b == null) {
             return a == b;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
