### PR TITLE
Mongodump creates a Long type in field expireAfterSeconds

### DIFF
--- a/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
+++ b/library/v3m0/src/main/java/com/eightkdata/mongowp/mongoserver/api/safe/library/v3m0/pojos/IndexOptions.java
@@ -228,7 +228,7 @@ public class IndexOptions {
                     break;
                 }
                 case EXPIRE_AFTER_SECONDS_FIELD_NAME: {
-                    expireAfterSeconds = BsonReaderTool.getInteger(entry, EXPIRE_AFTER_SECONDS_FIELD);
+                    expireAfterSeconds = BsonReaderTool.getNumeric(entry, EXPIRE_AFTER_SECONDS_FIELD.getFieldName()).intValue();
                     break;
                 }
                 case KEYS_FIELD_NAME: {


### PR DESCRIPTION
Mongodump creates a Long type for expireAfterSeconds field:

`		"expireAfterSeconds": {
			"$numberLong": "100"
		}`

In import process ToroDb can't cast the value