### PR TITLE
Removed the install section on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ before_script:
 cache:
   directories:
     - '$HOME/.sonar/cache'
-
-install:
-- mvn dependency:go-offline
   
 after_success:
   - if [[ $TRAVIS_REPO_SLUG = 8kdata/mongowp ]]; then bash <(curl -s https://codecov.io/bash) || echo 'Codecov did not collect coverage reports'; else echo 'Codecov not notified'; fi


### PR DESCRIPTION
The install section on .travis.yml was executing
mvn dependency:go-offline, which fails on travis because it tries to
fetch libraries that are on the reactor