### PR TITLE
Travis will print checkstyle errors but not warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 dist: trusty
-script: mvn -Psafer -Pintegration -B -e -T 1C verify
+script: mvn -Psafer -Pintegration -B -e -T 1C -Dcheckstyle.consoleOutput=false verify
 jdk: oraclejdk8
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ cache:
     - '$HOME/.sonar/cache'
 
 install:
-- mvn dependency:go-offline
+- mvn dependency:go-offline -q
   
 after_success:
   - if [[ $TRAVIS_REPO_SLUG = 8kdata/mongowp ]]; then bash <(curl -s https://codecov.io/bash) || echo 'Codecov did not collect coverage reports'; else echo 'Codecov not notified'; fi

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,6 @@
         <mongowp.buildtools.version>0.50.0</mongowp.buildtools.version>
         <netty.version>4.0.42.Final</netty.version>
         <license.header.file>com/eightkdata/mongowp/buildtools/mongowp-license.txt</license.header.file>
-        <checkstyle.config.location>com/eightkdata/mongowp/buildtools/checkstyle.xml</checkstyle.config.location>
         
         <!-- SonarQube properties -->
         <sonar.projectName>MongoWP</sonar.projectName>
@@ -84,6 +83,10 @@
         <sonar.links.ci>https://travis-ci.org/8kdata/mongowp</sonar.links.ci>
         <sonar.links.scm>https://github.com/8kdata/mongowp</sonar.links.scm>
         <sonar.links.issue>https://github.com/8kdata/mongowp/issues</sonar.links.issue>
+        
+        <!-- Checkstyle properties-->
+        <checkstyle.config.location>com/eightkdata/mongowp/buildtools/checkstyle.xml</checkstyle.config.location>
+        <checkstyle.consoleOutput>true</checkstyle.consoleOutput>
     </properties>
 
     <dependencyManagement>
@@ -301,9 +304,6 @@
                     <execution>
                         <id>validate</id>
                         <configuration>
-                            <!--<configLocation>google_checks.xml</configLocation>-->
-                            <consoleOutput>true</consoleOutput>
-                            <!--<failsOnError>true</failsOnError>-->
                             <linkXRef>false</linkXRef>
                             <violationSeverity>error</violationSeverity>
                         </configuration>


### PR DESCRIPTION
Travis logs were not totally printed because they were too long (>10k
lines). To solve that, checkstyle warnings will not be printed