### PR TITLE
Removed the install section, as it could produce problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ before_script:
 cache:
   directories:
     - '$HOME/.sonar/cache'
-
-install:
-- mvn dependency:go-offline -q
   
 after_success:
   - if [[ $TRAVIS_REPO_SLUG = 8kdata/mongowp ]]; then bash <(curl -s https://codecov.io/bash) || echo 'Codecov did not collect coverage reports'; else echo 'Codecov not notified'; fi


### PR DESCRIPTION
The install section said something like that:
install:
  - mvn dependency:go-offline -q

The idea behind that is that dependencies can be downloaded before the
script is executed, so the script is easier to read. But... that
pluggin also tries to resolve the dependencies to other project defined
on the same multiproject tree (aka "sibling projects"). This can work
meanwhile Nexus contains the previous snapshots, but not when a new
release is done.